### PR TITLE
ASoC TFA9890: Cancel monitor work without locking mutex

### DIFF
--- a/sound/soc/codecs/tfa9890/tfa98xx.c
+++ b/sound/soc/codecs/tfa9890/tfa98xx.c
@@ -257,8 +257,6 @@ int tfa98xx_bulk_write_raw(struct snd_soc_codec *codec, const u8 *data, u8 count
 }
 
 
-#ifndef VENDOR_EDIT
-/*suzhiguang@MultiMedia.AudioDrv, 2015-08-24,remove monitor,it will cause system crash because of mutex lock*/
 static void tfa98xx_monitor(struct work_struct *work)
 {
 	
@@ -318,7 +316,6 @@ static void tfa98xx_monitor(struct work_struct *work)
 	mutex_unlock(&tfa98xx->dsp_init_lock);
 
 }
-#endif
 
 static void tfa98xx_dsp_init(struct work_struct *work)
 {
@@ -416,13 +413,12 @@ static int tfa98xx_digital_mute(struct snd_soc_dai *dai, int mute)
 
 	pr_debug("state: %d\n", mute);
 
+        if (mute)
+            cancel_delayed_work_sync(&tfa98xx->delay_work);
+
 	mutex_lock(&tfa98xx->dsp_init_lock);
 
 	if (mute) {
-#ifndef VENDOR_EDIT
-/*suzhiguang@MultiMedia.AudioDrv, 2015-08-24,remove monitor,it will cause system crash because of mutex lock*/
-		cancel_delayed_work_sync(&tfa98xx->delay_work);
-#endif
 
 		/*
 		 * need to wait for amp to stop switching, to minimize
@@ -441,10 +437,7 @@ static int tfa98xx_digital_mute(struct snd_soc_dai *dai, int mute)
 		 */
 		tfa98xx_dsp_quickstart(tfa98xx, tfa98xx->profile, tfa98xx->vstep);		
 		test = 1;
-#ifndef VENDOR_EDIT
-/*suzhiguang@MultiMedia.AudioDrv, 2015-08-24,remove monitor,it will cause system crash because of mutex lock*/
 		queue_delayed_work(tfa98xx->tfa98xx_wq, &tfa98xx->delay_work, 5*HZ);
-#endif
 	}
 
 	mutex_unlock(&tfa98xx->dsp_init_lock);
@@ -680,10 +673,7 @@ int tfa98xx_set_stop_ctl(struct snd_kcontrol *kcontrol,
 	struct tfa98xx *tfa98xx = snd_soc_codec_get_drvdata(codec);
 
 	if ((ucontrol->value.integer.value[0] != 0) && !tfa98xx_is_pwdn(tfa98xx)) {
-#ifndef VENDOR_EDIT
-/*suzhiguang@MultiMedia.AudioDrv, 2015-08-24,remove monitor,it will cause system crash because of mutex lock*/
 		cancel_delayed_work_sync(&tfa98xx->delay_work);
-#endif
 
 		tfa98xx_dsp_stop(tfa98xx);
 	}
@@ -897,10 +887,7 @@ static int tfa98xx_i2c_probe(struct i2c_client *i2c,
 
 	INIT_WORK(&tfa98xx->init_work, tfa98xx_dsp_init);
 
-#ifndef VENDOR_EDIT
-/*suzhiguang@MultiMedia.AudioDrv, 2015-08-24,remove monitor,it will cause system crash because of mutex lock*/
 	INIT_DELAYED_WORK(&tfa98xx->delay_work, tfa98xx_monitor);
-#endif
 
 	/* register codec */
 	ret = snd_soc_register_codec(&i2c->dev, &tfa98xx_soc_codec,


### PR DESCRIPTION
Cancel the tfa9890 delayed monitor work (synchronously) without holding
the dsp init mutex.  If the work is running, it's a guaranteed
deadlock.

Bug: 17180173 Couldn't wake up device after pressing power button
Signed-off-by: Chris Fries <cfries@motorola.com>